### PR TITLE
chore: :see_no_evil: add `.quarto_ipynb` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.quarto/
 /_site/
+
+**/*.quarto_ipynb


### PR DESCRIPTION
Added automatically.

Needs no review.